### PR TITLE
Update CodeTF to support interactive codemods

### DIFF
--- a/codetf.json
+++ b/codetf.json
@@ -76,13 +76,13 @@
              "line" : "54", // the line number we want to change
              "column" : "9", // the column we want to change
              "proposedDiff" : "... proposed code diff here...", // the udiff format of the draft fix we could envision issuing
-             "values" : [
+             "values" : [ // the values we would need from the user in order to perform the change
                {
-                  "question" : "What would you like the session timeout to be (in minutes)?",
-                  "name" : "timeout",
-                  "type" : "integer",
-                  "description" : "a non-negative integer that represents the Jakarta session timeout for a web.xml file",
-                  "proposedValue" : "30"
+                  "question" : "What would you like the session timeout to be (in minutes)?", // a natural language question we want to pose to the user
+                  "name" : "timeout", // the name of the value we are asking for
+                  "type" : "integer", // the data type (one of integer, boolean, string)
+                  "description" : "a non-negative integer that represents the Jakarta session timeout for a web.xml file", // a description of the value
+                  "proposedValue" : "30" // what we think a sane default value would be in order to anchor the user towards reasonable values if they need it
                }
              ]
            }


### PR DESCRIPTION
Imagine we want to create a codemod for changing the `<session-timeout>` value of a web application. We might see it is `600` (minutes), and that feels way too big. Or, maybe we don't see it at all, and so the user isn't aware it might be uncomfortably high.

But, suggesting the "right" answer is tough because it is very business-dependent. We could guess at the number, but prompting the user for a value might be a lot more productive, and our approach to the user should probably different if we don't have high confidence in a placeholder value.

The CodeTF has to have a way of communicating this type of "needs-more-information-before-changing" discovery. This could be used by software reading the CodeTF to prompt the user for changes.

It may be worth noting that codemod ran via CLIs need not use this format, and can instead ask the user questions inline to the running of the codemod. Therefore, this is most valuable in situations where user interaction isn't immediately available.