### PR TITLE
CodeTF Parameters

### DIFF
--- a/codetf.json
+++ b/codetf.json
@@ -82,7 +82,7 @@
                     {
                       "question" : "What would you like the session timeout to be (in minutes)?", // a natural language question we want to pose to the user (required)
                       "name" : "timeout", // the name of the value we are asking for (required)
-                      "type" : "number", // the data type (one of number, boolean, string, string default, required)
+                      "type" : "number", // the data type (one of number, boolean, string, string default) (optional)
                       "label" : "a non-negative integer that represents the Jakarta session timeout for a web.xml file", // a description of the value (optional)
                       "defaultValue" : "30" // what we think a sane default value would be in order to anchor the user towards reasonable values if they need it (required)
                     }


### PR DESCRIPTION
The new proposal is for CodeTF to add a `parameters` field to existing `changeset` entries. Each individual file change can be associated with multiple `parameters`.

For the downstream consumers of CodeTF to interact with it typical fashion, the changes to disk must actually be made. The previous proposal introduced too much complexity as an alternate diff form, without any new, incremental value. 

It is imagined that tools will analyze these `parameters` from the CodeTF, get customizations from users, and then re-invoke their codemods with the correct parameters if necessary to get more customized codemod changes.

Although the spec hasn't been developed for what a CLI might do, the "re-invoking" could look something like this:

```
$ ./my-timeout-limiting-codemod --parameter="pixee:java/my-timeout-codemod;src/web.xml;17,60" --parameter="pixee:java/secure-random;src/MyTokenGenerator.java;8"
```

Whereas  the `--parameter` flag is a triplet containing the `codemod`, `location` and `value` of a CodeTF `parameter`. Each parameter must be uniquely tied back to its original CodeTF `changeset` entry's parameter, and this triplet is sufficient for that.