### PR TITLE
📝 Indicate Where GitHub Flavored Markdown Is Supported

### DIFF
--- a/codetf.json
+++ b/codetf.json
@@ -18,7 +18,7 @@
      {
         "codemod" : "pixee:java/deserialization", // an ID that maps to a vendor's knowledgebase
         "summary" : "Hardened object deserialization calls against attack", // a phrase describing the changes made (required)
-        "description" : "Lengthier description about deserialization risks, protections, etc...", // (required)
+        "description" : "Lengthier GitHub Flavored Markdown description about deserialization risks, protections, etc...", // (required)
         "references" : [ // set of further reading for understanding the issue or changes (optional)
             {
                 "url" : "https://www.oracle.com/technetwork/java/seccodeguide-139067.html#8", // the url (required)


### PR DESCRIPTION
Adds to CodeTF example to clearly indicate which text fields contain GitHub Flavored Markdown vs plaintext.