### PR TITLE
Add optional `detectionTool` field to CodeTF result

### DIFF
--- a/codetf.json
+++ b/codetf.json
@@ -20,6 +20,11 @@
         "codemod" : "pixee:java/deserialization", // an ID that maps to a vendor's knowledgebase
         "summary" : "Hardened object deserialization calls against attack", // a phrase describing the changes made (required)
         "description" : "Lengthier description about deserialization risks, protections, etc...", // (required)
+        "detectionTool": { // metadata about the tool that detected the issue (optional, default assumes codemodder itself)
+            "name": "Name of the tool that detected the issue", (required)
+            "ruleId": "ID of the tool vendor rule that detected the issue", (required)
+            "ruleName": "Name of the tool vendor rule that detected the issue", (required)
+        },
         "references" : [ // set of further reading for understanding the issue or changes (optional)
             {
                 "url" : "https://www.oracle.com/technetwork/java/seccodeguide-139067.html#8", // the url (required)


### PR DESCRIPTION
This doesn't entirely address #17 but I think it adds a small, required set of fields that we definitely want.

In a subsequent change we can add `findings` which offers details about which findings were remediated and which were not.

We can build upon this as necessary but for now I hope we can come to an agreement on the field names.

Part of the goal here is to enable consistent reporting of tool remediation by upstream tools. Rather than encoding things like the tool name in the `summary` we can enable consistent handling.