### PR TITLE
Associate findings with changes or with new unfixed array

### DIFF
--- a/codetf.schema.json
+++ b/codetf.schema.json
@@ -237,8 +237,33 @@
             "description": "Whether the finding was fixed by the codemod"
           },
           "reason": {
-            "type": "string",
-            "description": "Reason the finding was not fixed"
+            "type": "array",
+            "items": {
+              "failure": {
+                "type": "object",
+                "properties": {
+                  "description": {
+                    "type": "string",
+                    "description": "A human-readable description of the reason the fix failed at this location"
+                  },
+                  "path": {
+                    "type": "string",
+                    "description": "Path of the file where the fix failed to apply"
+                  },
+                  "line": {
+                    "type": "integer",
+                    "description": "(Optional) line number where the fix failed to apply"
+                  },
+                  "snippet": {
+                    "type": "string",
+                    "description": "(Optional) snippet of code that we failed to fix"
+                  }
+                },
+                "required": ["description", "path"],
+                "additionalProperties": true
+              }
+            },
+            "minItems": 1
           }
         },
         "additionalProperties": true,

--- a/codetf.schema.json
+++ b/codetf.schema.json
@@ -157,29 +157,6 @@
       "required": ["path", "diff", "changes"]
     },
 
-    "unfixed": {
-      "type": "object",
-      "properties": {
-        "path": {
-          "type": "string",
-          "description": "The path of the file (relative to the directory) that was not fixed"
-        },
-        "lineNumber": {
-          "type": "integer",
-          "description": "The line number that was not fixed"
-        },
-        "reason": {
-          "type": "string",
-          "description": "A human-readable description of the reason the file was not fixed"
-        },
-        "finding": {
-          "$ref": "#/definitions/detector/finding",
-          "description": "The finding that was not fixed at this location"
-        }
-      },
-      "required": ["path", "reason", "finding"]
-    },
-
     "change": {
       "type": "object",
       "properties": {
@@ -248,7 +225,7 @@
     },
 
     "detector": {
-      "finding": {
+      "fixedFinding": {
         "type": "object",
         "properties": {
           "id": {
@@ -261,17 +238,19 @@
           }
         },
         "additionalProperties": true,
-        "required": ["id", "rule", "path"]
-      },
-      "fixedFinding": {
-        "$ref": "#/definitions/detector/finding",
-        "additionalProperties": true,
-        // TODO: can we do it this way??
         "required": ["id", "rule"]
       },
       "unfixedFinding": {
-        "$ref": "#/definitions/detector/finding",
+        "type": "object",
         "properties": {
+          "id": {
+            "type": "string",
+            "description": "A unique identifier for the finding (e.g. 'guid' from SARIF)"
+          },
+          "rule": {
+            "$ref": "#/definitions/detector/rule",
+            "description": "The rule that detected the issue"
+          },
           "path": {
             "type": "string",
             "description": "The path of the file (relative to the directory) that was not fixed"

--- a/codetf.schema.json
+++ b/codetf.schema.json
@@ -97,6 +97,11 @@
           "description": "The changes for a given codemod",
           "items": { "$ref": "#/definitions/changeset" },
           "minItems": 0
+        },
+        "unfixed": {
+          "type": "array",
+          "description": "A set of file paths for files that the tool failed to fix",
+          "items": { "$ref": "#/definitions/unfixedFinding" }
         }
       },
       "required": ["codemod", "summary", "description", "changeset"]
@@ -152,6 +157,29 @@
       "required": ["path", "diff", "changes"]
     },
 
+    "unfixed": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "The path of the file (relative to the directory) that was not fixed"
+        },
+        "lineNumber": {
+          "type": "integer",
+          "description": "The line number that was not fixed"
+        },
+        "reason": {
+          "type": "string",
+          "description": "A human-readable description of the reason the file was not fixed"
+        },
+        "finding": {
+          "$ref": "#/definitions/detector/finding",
+          "description": "The finding that was not fixed at this location"
+        }
+      },
+      "required": ["path", "reason", "finding"]
+    },
+
     "change": {
       "type": "object",
       "properties": {
@@ -177,6 +205,10 @@
           "type": "array",
           "description": "The package actions that were needed to support changes to the file",
           "items": { "$ref": "#/definitions/packageAction" }
+        },
+        "finding": {
+          "$ref": "#/definitions/detector/fixedFinding",
+          "description": "The finding that was fixed at this location"
         }
       },
       "required": ["lineNumber", "diffSide"]
@@ -209,19 +241,10 @@
         "name": {
           "type": "string",
           "description": "Name of the tool that detected the issue"
-        },
-        "rule": {
-          "$ref": "#/definitions/detector/rule",
-          "description": "The rule that detected the issue"
-        },
-        "findings": {
-          "type": "array",
-          "items": { "$ref": "#/definitions/detector/finding" },
-          "maxItems": 20
         }
       },
       "additionalProperties": true,
-      "required": ["name", "rule", "findings"]
+      "required": ["name"]
     },
 
     "detector": {
@@ -232,48 +255,38 @@
             "type": "string",
             "description": "A unique identifier for the finding (e.g. 'guid' from SARIF)"
           },
-          "fixed": {
-            "type": "boolean",
-            "description": "Whether the finding was fixed by the codemod"
-          },
-          "reason": {
-            "type": "array",
-            "items": {
-              "failure": {
-                "type": "object",
-                "properties": {
-                  "description": {
-                    "type": "string",
-                    "description": "A human-readable description of the reason the fix failed at this location"
-                  },
-                  "path": {
-                    "type": "string",
-                    "description": "Path of the file where the fix failed to apply"
-                  },
-                  "line": {
-                    "type": "integer",
-                    "description": "(Optional) line number where the fix failed to apply"
-                  },
-                  "snippet": {
-                    "type": "string",
-                    "description": "(Optional) snippet of code that we failed to fix"
-                  }
-                },
-                "required": ["description", "path"],
-                "additionalProperties": true
-              }
-            },
-            "minItems": 1
+          "rule": {
+            "$ref": "#/definitions/detector/rule",
+            "description": "The rule that detected the issue"
           }
         },
         "additionalProperties": true,
-        "required": ["id", "fixed"],
-        "if": {
-          "properties": {
-            "fixed": { "boolean": false }
+        "required": ["id", "rule", "path"]
+      },
+      "fixedFinding": {
+        "$ref": "#/definitions/detector/finding",
+        "additionalProperties": true,
+        // TODO: can we do it this way??
+        "required": ["id", "rule"]
+      },
+      "unfixedFinding": {
+        "$ref": "#/definitions/detector/finding",
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "The path of the file (relative to the directory) that was not fixed"
           },
-          "required": ["reason"]
-        }
+          "lineNumber": {
+            "type": "integer",
+            "description": "The line number that was not fixed"
+          },
+          "reason": {
+            "type": "string",
+            "description": "A human-readable description of the reason the file was not fixed"
+          }
+        },
+        "additionalProperties": true,
+        "required": ["id", "rule", "path", "reason"]
       },
       "rule": {
         "type": "object",


### PR DESCRIPTION
For diagnostic and storytelling purposes, it is desirable for downstream consumers to know which findings are associated with which changes, and which findings were not fixed, where they were attempted, and for what reason.

This update includes the following modifications:
* `detectionTool` no longer contains finding metadata. It is purely for metadata about the tool itself. Eventually we might add other fields like `version`, `date`, etc.
* `change` now has a `fixedFinding` property
* We added a new array to `result` that represents unfixed findings, which include a reason for being unfixed