### PR TITLE
Fixed findings should be an array

### DIFF
--- a/codetf.schema.json
+++ b/codetf.schema.json
@@ -187,9 +187,10 @@
           "description": "The package actions that were needed to support changes to the file",
           "items": { "$ref": "#/definitions/packageAction" }
         },
-        "finding": {
-          "$ref": "#/definitions/detector/fixedFinding",
-          "description": "The finding that was fixed at this location"
+        "findings": {
+          "type": "array",
+          "description": "List of findings that were fixed at this location",
+          "items": { "$ref": "#/definitions/detector/fixedFinding" }
         }
       },
       "required": ["lineNumber", "diffSide"]


### PR DESCRIPTION
The Java CodeTF bindings module already reflects this update but for some reason it was missed in the schema itself.