### PR TITLE
🦺 Include Finding ID in CodeTF Only When Provided by the Tool

### DIFF
--- a/codetf.schema.json
+++ b/codetf.schema.json
@@ -268,7 +268,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "A unique identifier for the finding (e.g. 'guid' from SARIF)"
+            "description": "A unique identifier for the finding, if provided by the detection tool. Concerning logically equivalent findings across scans, this identifier has the same semantics as `guid` from SARIF."
           },
           "rule": {
             "$ref": "#/definitions/detector/rule",
@@ -276,14 +276,14 @@
           }
         },
         "additionalProperties": true,
-        "required": ["id", "rule"]
+        "required": ["rule"]
       },
       "unfixedFinding": {
         "type": "object",
         "properties": {
           "id": {
             "type": "string",
-            "description": "A unique identifier for the finding (e.g. 'guid' from SARIF)"
+            "description": "A unique identifier for the finding, if provided by the detection tool. Concerning logically equivalent findings across scans, this identifier has the same semantics as `guid` from SARIF."
           },
           "rule": {
             "$ref": "#/definitions/detector/rule",
@@ -303,7 +303,7 @@
           }
         },
         "additionalProperties": true,
-        "required": ["id", "rule", "path", "reason"]
+        "required": ["rule", "path", "reason"]
       },
       "rule": {
         "type": "object",


### PR DESCRIPTION
In cases where a tool does not provide a finding identifier that has the same semantics as [guid from SARIF](https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141790891), codemodder does more harm than good when it uses some fallback value to satisfy the required field constraint. I know this, because I'm currently working on the data model for correlating codemod changes to tool issues :-)

We should make the result identifier for fixed / unfixed findings optional. If the tool provides a result ID, then codemodder shall use it. But when the tool provides no such identifier (Snyk 👀), codemodder should not make one up.