### PR TITLE
Add `fixedFIndings` at changeset level

### DIFF
--- a/codetf.schema.json
+++ b/codetf.schema.json
@@ -180,6 +180,11 @@
         "provisional": {
           "type": "boolean",
           "description": "Indicates that the fix is provisional"
+        },
+        "fixedFindings": {
+          "type": "array",
+          "description": "List of findings that were fixed by this changeset",
+          "items": { "$ref": "#/definitions/detector/fixedFinding" }
         }
       },
       "required": ["path", "diff", "changes"]

--- a/codetf.schema.json
+++ b/codetf.schema.json
@@ -183,7 +183,7 @@
         },
         "fixedFindings": {
           "type": "array",
-          "description": "List of findings that were fixed by this changeset",
+          "description": "List of findings that were fixed by this changeset. Used for findings that can't be attached to a specific change.",
           "items": { "$ref": "#/definitions/detector/fixedFinding" }
         }
       },

--- a/codetf.schema.json
+++ b/codetf.schema.json
@@ -216,7 +216,7 @@
           "description": "The package actions that were needed to support changes to the file",
           "items": { "$ref": "#/definitions/packageAction" }
         },
-        "findings": {
+        "fixedFindings": {
           "type": "array",
           "description": "List of findings that were fixed at this location",
           "items": { "$ref": "#/definitions/detector/fixedFinding" }


### PR DESCRIPTION
* In some cases it is more reliable to attach fixed finding metadata directly to the `changeset` than it is to identify an individual change
* Implementations should honor both possibilities
* Also updated `change.findings` to `change.fixedFindings` to conform to the current behavior of the Java CodeTF bindings